### PR TITLE
A: https://www.bluenile.com/

### DIFF
--- a/easyprivacy/easyprivacy_thirdparty.txt
+++ b/easyprivacy/easyprivacy_thirdparty.txt
@@ -1494,7 +1494,6 @@
 ||pixel.roymorgan.com^
 ||pixel.s3xified.com^
 ||pixel.safe-installation.com^
-||pixel.snapsmedia.io^
 ||pixel.solvemedia.com^
 ||pixel.sprinklr.com^
 ||pixel.tree.com^


### PR DESCRIPTION
Fixes issue where customer service chatbot does not appear on page.

`events/pixelEvent` listed on [easyprivacy_general.txt](https://github.com/easylist/easylist/blob/8a64d461463d0ead5142bfd3dd69f993b345532b/easyprivacy/easyprivacy_general.txt#L1758) successfully blocks calls to the Snaps tracking endpoint. 

![Screenshot](https://user-images.githubusercontent.com/32558407/128748731-3af670f6-3600-442c-9198-98e3bd2ccbfe.png)
